### PR TITLE
Fixing kms issues

### DIFF
--- a/modules/bootstrap/locals.tf
+++ b/modules/bootstrap/locals.tf
@@ -5,7 +5,6 @@ locals {
   prefix = var.prefix
   tags   = [local.prefix, local.name]
   # TODO: explore (DA always keep it true)
-  skip_iam_authorization_policy = true
 
   schematics_reserved_cidrs = [
     "169.44.0.0/14",

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -35,7 +35,7 @@ module "bastion_vsi" {
   user_data                     = data.template_file.bastion_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = local.skip_iam_authorization_policy
+  skip_iam_authorization_policy = false
   boot_volume_encryption_key    = var.boot_volume_encryption_key
 }
 
@@ -58,6 +58,6 @@ module "bootstrap_vsi" {
   user_data                     = data.template_file.bootstrap_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = local.skip_iam_authorization_policy
+  skip_iam_authorization_policy = var.enable_bastion ? true : false
   boot_volume_encryption_key    = var.boot_volume_encryption_key
 }

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -36,6 +36,7 @@ module "bastion_vsi" {
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
   skip_iam_authorization_policy = false
+  existing_kms_instance_guid    = var.existing_kms_instance_guid
   boot_volume_encryption_key    = var.boot_volume_encryption_key
 }
 
@@ -59,5 +60,6 @@ module "bootstrap_vsi" {
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
   skip_iam_authorization_policy = var.enable_bastion ? true : false
+  existing_kms_instance_guid    = var.existing_kms_instance_guid
   boot_volume_encryption_key    = var.boot_volume_encryption_key
 }

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -107,3 +107,9 @@ variable "boot_volume_encryption_key" {
   default     = null
   description = "CRN of boot volume encryption key"
 }
+
+variable "existing_kms_instance_guid" {
+  type        = string
+  default     = null
+  description = "GUID of boot volume encryption key"
+}

--- a/modules/landing_zone/locals.tf
+++ b/modules/landing_zone/locals.tf
@@ -338,7 +338,7 @@ locals {
 
   # Prerequisite: Existing key protect instance is not supported, always create a key management instance
   active_keys = [
-    var.key_management != null ? {
+    var.key_management != null && var.kms_encryption_enabled == true ? {
       name = format("%s-vsi-key", var.prefix)
     } : null,
     var.enable_cos_integration ? {

--- a/modules/landing_zone/outputs.tf
+++ b/modules/landing_zone/outputs.tf
@@ -95,7 +95,7 @@ output "protocol_subnets" {
 
 output "key_management_guid" {
   description = "GUID for KMS instance"
-  value       = module.landing_zone[0].key_management_guid
+  value       = var.key_management != null && var.kms_encryption_enabled == true ? module.landing_zone[0].key_management_guid : null
 }
 
 # TODO: Find a way to get CRN needed for VSI boot drive encryption

--- a/modules/landing_zone/outputs.tf
+++ b/modules/landing_zone/outputs.tf
@@ -93,10 +93,15 @@ output "protocol_subnets" {
   ]
 }
 
+output "key_management_guid" {
+  description = "GUID for KMS instance"
+  value       = module.landing_zone[0].key_management_guid
+}
+
 # TODO: Find a way to get CRN needed for VSI boot drive encryption
 output "boot_volume_encryption_key" {
   description = "Boot volume encryption key"
-  value       = var.key_management != null ? module.landing_zone[*].key_map[format("%s-vsi-key", var.prefix)] : null
+  value       = var.key_management != null && var.kms_encryption_enabled == true ? module.landing_zone[*].key_map[format("%s-vsi-key", var.prefix)] : null
 }
 
 # TODO: Observability data

--- a/modules/landing_zone/variables.tf
+++ b/modules/landing_zone/variables.tf
@@ -251,6 +251,12 @@ variable "key_management" {
   description = "null/key_protect/hs_crypto"
 }
 
+variable "kms_encryption_enabled" {
+  description = "Set to true when key management is set"
+  type        = bool
+  default     = true
+}
+
 variable "hpcs_instance_name" {
   type        = string
   default     = null

--- a/modules/landing_zone_vsi/locals.tf
+++ b/modules/landing_zone_vsi/locals.tf
@@ -8,6 +8,7 @@ locals {
   vsi_interfaces = ["eth0", "eth1"]
   bms_interfaces = ["ens1", "ens2"]
   # TODO: explore (DA always keep it true)
+  skip_iam_authorization_policy = true
 
   block_storage_volumes = [for volume in var.nsd_details : {
     name           = format("nsd-%s", index(var.nsd_details, volume) + 1)

--- a/modules/landing_zone_vsi/locals.tf
+++ b/modules/landing_zone_vsi/locals.tf
@@ -8,7 +8,6 @@ locals {
   vsi_interfaces = ["eth0", "eth1"]
   bms_interfaces = ["ens1", "ens2"]
   # TODO: explore (DA always keep it true)
-  skip_iam_authorization_policy = false
 
   block_storage_volumes = [for volume in var.nsd_details : {
     name           = format("nsd-%s", index(var.nsd_details, volume) + 1)

--- a/modules/landing_zone_vsi/main.tf
+++ b/modules/landing_zone_vsi/main.tf
@@ -62,7 +62,7 @@ module "login_vsi" {
   user_data                     = data.template_file.login_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = true
+  skip_iam_authorization_policy = local.skip_iam_authorization_policy
   boot_volume_encryption_key    = var.boot_volume_encryption_key
 }
 
@@ -85,7 +85,7 @@ module "management_vsi" {
   user_data                     = data.template_file.management_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = true
+  skip_iam_authorization_policy = local.skip_iam_authorization_policy
   boot_volume_encryption_key    = var.boot_volume_encryption_key
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.management_instances[count.index]["count"])%(length(var.placement_group_ids))]
@@ -110,7 +110,7 @@ module "compute_vsi" {
   user_data                     = data.template_file.compute_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = true
+  skip_iam_authorization_policy = local.skip_iam_authorization_policy
   boot_volume_encryption_key    = var.boot_volume_encryption_key
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.static_compute_instances[count.index]["count"])%(length(var.placement_group_ids))]
@@ -136,7 +136,7 @@ module "storage_vsi" {
   vpc_id                        = var.vpc_id
   block_storage_volumes         = local.enable_block_storage ? local.block_storage_volumes : []
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = true
+  skip_iam_authorization_policy = local.skip_iam_authorization_policy
   boot_volume_encryption_key    = var.boot_volume_encryption_key
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.storage_instances[count.index]["count"])%(length(var.placement_group_ids))]
@@ -161,7 +161,7 @@ module "protocol_vsi" {
   user_data                     = data.template_file.protocol_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = true
+  skip_iam_authorization_policy = local.skip_iam_authorization_policy
   boot_volume_encryption_key    = var.boot_volume_encryption_key
   # Bug: 5847 - LB profile & subnets are not configurable
   # load_balancers        = local.enable_load_balancer ? local.load_balancers : []

--- a/modules/landing_zone_vsi/main.tf
+++ b/modules/landing_zone_vsi/main.tf
@@ -64,7 +64,6 @@ module "login_vsi" {
   kms_encryption_enabled        = var.kms_encryption_enabled
   skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
-  existing_kms_instance_guid    = var.existing_kms_instance_guid
 }
 
 module "management_vsi" {
@@ -88,7 +87,6 @@ module "management_vsi" {
   kms_encryption_enabled        = var.kms_encryption_enabled
   skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
-  existing_kms_instance_guid    = var.existing_kms_instance_guid
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.management_instances[count.index]["count"])%(length(var.placement_group_ids))]
 }
@@ -114,7 +112,6 @@ module "compute_vsi" {
   kms_encryption_enabled        = var.kms_encryption_enabled
   skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
-  existing_kms_instance_guid    = var.existing_kms_instance_guid
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.static_compute_instances[count.index]["count"])%(length(var.placement_group_ids))]
 }
@@ -141,7 +138,6 @@ module "storage_vsi" {
   kms_encryption_enabled        = var.kms_encryption_enabled
   skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
-  existing_kms_instance_guid    = var.existing_kms_instance_guid
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.storage_instances[count.index]["count"])%(length(var.placement_group_ids))]
 }
@@ -167,7 +163,6 @@ module "protocol_vsi" {
   kms_encryption_enabled        = var.kms_encryption_enabled
   skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
-  existing_kms_instance_guid    = var.existing_kms_instance_guid
   # Bug: 5847 - LB profile & subnets are not configurable
   # load_balancers        = local.enable_load_balancer ? local.load_balancers : []
   secondary_allow_ip_spoofing = true

--- a/modules/landing_zone_vsi/main.tf
+++ b/modules/landing_zone_vsi/main.tf
@@ -62,7 +62,7 @@ module "login_vsi" {
   user_data                     = data.template_file.login_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = false
+  skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
   existing_kms_instance_guid    = var.existing_kms_instance_guid
 }

--- a/modules/landing_zone_vsi/main.tf
+++ b/modules/landing_zone_vsi/main.tf
@@ -43,7 +43,6 @@ module "storage_sg" {
   vpc_id                       = var.vpc_id
 }
 
-
 module "login_vsi" {
   count                         = length(var.login_instances)
   source                        = "terraform-ibm-modules/landing-zone-vsi/ibm"
@@ -63,8 +62,9 @@ module "login_vsi" {
   user_data                     = data.template_file.login_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = local.skip_iam_authorization_policy
+  skip_iam_authorization_policy = false
   boot_volume_encryption_key    = var.boot_volume_encryption_key
+  existing_kms_instance_guid    = var.existing_kms_instance_guid
 }
 
 module "management_vsi" {
@@ -86,8 +86,9 @@ module "management_vsi" {
   user_data                     = data.template_file.management_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = local.skip_iam_authorization_policy
+  skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
+  existing_kms_instance_guid    = var.existing_kms_instance_guid
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.management_instances[count.index]["count"])%(length(var.placement_group_ids))]
 }
@@ -111,8 +112,9 @@ module "compute_vsi" {
   user_data                     = data.template_file.compute_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = local.skip_iam_authorization_policy
+  skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
+  existing_kms_instance_guid    = var.existing_kms_instance_guid
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.static_compute_instances[count.index]["count"])%(length(var.placement_group_ids))]
 }
@@ -137,8 +139,9 @@ module "storage_vsi" {
   vpc_id                        = var.vpc_id
   block_storage_volumes         = local.enable_block_storage ? local.block_storage_volumes : []
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = local.skip_iam_authorization_policy
+  skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
+  existing_kms_instance_guid    = var.existing_kms_instance_guid
   placement_group_id            = var.placement_group_ids
   #placement_group_id = var.placement_group_ids[(var.storage_instances[count.index]["count"])%(length(var.placement_group_ids))]
 }
@@ -162,8 +165,9 @@ module "protocol_vsi" {
   user_data                     = data.template_file.protocol_user_data.rendered
   vpc_id                        = var.vpc_id
   kms_encryption_enabled        = var.kms_encryption_enabled
-  skip_iam_authorization_policy = local.skip_iam_authorization_policy
+  skip_iam_authorization_policy = true
   boot_volume_encryption_key    = var.boot_volume_encryption_key
+  existing_kms_instance_guid    = var.existing_kms_instance_guid
   # Bug: 5847 - LB profile & subnets are not configurable
   # load_balancers        = local.enable_load_balancer ? local.load_balancers : []
   secondary_allow_ip_spoofing = true

--- a/modules/landing_zone_vsi/variables.tf
+++ b/modules/landing_zone_vsi/variables.tf
@@ -304,6 +304,12 @@ variable "boot_volume_encryption_key" {
   description = "CRN of boot volume encryption key"
 }
 
+variable "existing_kms_instance_guid" {
+  type        = string
+  default     = null
+  description = "GUID of boot volume encryption key"
+}
+
 ##############################################################################
 # TODO: Auth Server (LDAP/AD) Variables
 ##############################################################################

--- a/modules/landing_zone_vsi/variables.tf
+++ b/modules/landing_zone_vsi/variables.tf
@@ -304,12 +304,6 @@ variable "boot_volume_encryption_key" {
   description = "CRN of boot volume encryption key"
 }
 
-variable "existing_kms_instance_guid" {
-  type        = string
-  default     = null
-  description = "GUID of boot volume encryption key"
-}
-
 ##############################################################################
 # TODO: Auth Server (LDAP/AD) Variables
 ##############################################################################

--- a/solutions/hpc/locals.tf
+++ b/solutions/hpc/locals.tf
@@ -9,7 +9,8 @@ locals {
   # dependency: landing_zone -> bootstrap
   vpc_id                     = var.vpc == null ? one(module.landing_zone.vpc_id) : var.vpc
   bastion_subnets            = module.landing_zone.bastion_subnets
-  boot_volume_encryption_key = var.key_management != null ? one(module.landing_zone.boot_volume_encryption_key)["crn"] : null
+  boot_volume_encryption_key = (var.key_management != null && var.boot_volume_encryption_enabled == true) ? one(module.landing_zone.boot_volume_encryption_key)["crn"] : null
+  existing_kms_instance_guid = module.landing_zone.key_management_guid
   # Future use
   # skip_iam_authorization_policy = true
 }

--- a/solutions/hpc/locals.tf
+++ b/solutions/hpc/locals.tf
@@ -10,7 +10,7 @@ locals {
   vpc_id                     = var.vpc == null ? one(module.landing_zone.vpc_id) : var.vpc
   bastion_subnets            = module.landing_zone.bastion_subnets
   boot_volume_encryption_key = (var.key_management != null && var.boot_volume_encryption_enabled == true) ? one(module.landing_zone.boot_volume_encryption_key)["crn"] : null
-  existing_kms_instance_guid = module.landing_zone.key_management_guid
+  existing_kms_instance_guid = (var.key_management != null && var.boot_volume_encryption_enabled == true) ? module.landing_zone.key_management_guid : null
   # Future use
   # skip_iam_authorization_policy = true
 }

--- a/solutions/hpc/main.tf
+++ b/solutions/hpc/main.tf
@@ -46,6 +46,7 @@ module "bootstrap" {
   ssh_keys                   = var.bastion_ssh_keys
   allowed_cidr               = var.allowed_cidr
   boot_volume_encryption_key = local.boot_volume_encryption_key
+  existing_kms_instance_guid = local.existing_kms_instance_guid
   kms_encryption_enabled     = var.boot_volume_encryption_enabled
 }
 
@@ -78,7 +79,6 @@ module "landing_zone_vsi" {
   nsd_details                = var.nsd_details
   dns_domain_names           = var.dns_domain_names
   boot_volume_encryption_key = local.boot_volume_encryption_key
-  existing_kms_instance_guid = local.existing_kms_instance_guid
   kms_encryption_enabled     = var.boot_volume_encryption_enabled
 }
 

--- a/solutions/hpc/main.tf
+++ b/solutions/hpc/main.tf
@@ -11,6 +11,7 @@ module "landing_zone" {
   hpcs_instance_name     = var.hpcs_instance_name
   ibmcloud_api_key       = var.ibmcloud_api_key
   key_management         = var.key_management
+  kms_encryption_enabled = var.boot_volume_encryption_enabled
   ssh_keys               = var.bastion_ssh_keys
   bastion_subnets_cidr   = var.bastion_subnets_cidr
   management_instances   = var.management_instances
@@ -77,6 +78,7 @@ module "landing_zone_vsi" {
   nsd_details                = var.nsd_details
   dns_domain_names           = var.dns_domain_names
   boot_volume_encryption_key = local.boot_volume_encryption_key
+  existing_kms_instance_guid = local.existing_kms_instance_guid
   kms_encryption_enabled     = var.boot_volume_encryption_enabled
 }
 


### PR DESCRIPTION
### Description

This PR addresses fixes below issues:

```
│ Error: Invalid function argument
│ 
│   on .terraform/modules/hpc.bootstrap.bastion_vsi/main.tf line 4, in locals:
│    4:   validate_kms_values = !var.kms_encryption_enabled && var.boot_volume_encryption_key != null ? tobool("When passing values for var.boot_volume_encryption_key, you must set var.kms_encryption_enabled to true. Otherwise unset them to use default encryption") : true
│     ├────────────────
│     │ while calling tobool(v)
│ 
│ Invalid value for "v" parameter: cannot convert "When passing values for var.boot_volume_encryption_key, you must set
│ var.kms_encryption_enabled to true. Otherwise unset them to use default encryption" to bool; only the strings "true" or "false" are
│ allowed.

When var.skip_iam_authorization_policy is set to false, and var.kms_encryption_enabled to true, a value must be passed for var.existing_kms_instance_guid in order to create the auth policy

As we have kept skip_iam_authorization_policy to false so we need to pass existing_kms_instance_guid - https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone-vsi#input_skip_iam_authorization_policy

Error: [ERROR] Error creating authorization policy: The policy wasn't created because an access policy with identical attributes already exists. Please update the roles in the existing policy (aa8d849d-8cd1-46a3-90ad-649c3fc44b05), or update the one you're trying to assign to include a different attribute assignment. {
│     "StatusCode": 409,
│     "Headers": {
│         "Akamai-Grn": [
│             "0.24fdd417.1698676091.14b038a6"
│         ],
│         "Cache-Control": [
│             "no-cache,no-store"
│         ],
│         "Content-Length": [
│             "1535"
│         ],
│         "Content-Type": [
│             "application/json; charset=utf-8"
│         ],
│         "Date": [
│             "Mon, 30 Oct 2023 14:28:11 GMT"
│         ],
│         "Expires": [
│             "Thursday, 1 January 1970 00:00:00 GMT"
│         ],
│         "Pragma": [
│             "no-cache"
│         ],
│         "Response-Time": [
│             "219.335ms"
│         ],
│         "Strict-Transport-Security": [
│             "max-age=31536000; includeSubDomains"
│         ],
│         "Transaction-Id": [
│             "77c50d28c8e846ad858f5a1d2c23349e"
│         ],
│         "X-Proxy-Upstream-Service-Time": [
│             "246"
│         ],
│         "X-Response-Time": [
│             "221.742ms"
│         ]
│     },
│     "Result": {
│         "errors": [
│             {
│                 "code": "policy_conflict_error",
│                 "details": {
│                     "conflicts_with": {
│                         "etag": "1-d1f1e64e3c17e371d02f3c637fa178db",
│                         "policy": {
│                             "created_at": "2023-10-30T14:28:08.449Z",
│                             "created_by_id": "IBMid-6670005V46",
│                             "description": "Allow block storage volumes to be encrypted by Key Management instance.",
│                             "href": "https://iam.cloud.ibm.com/v1/policies/aa8d849d-8cd1-46a3-90ad-649c3fc44b05",
│                             "id": "aa8d849d-8cd1-46a3-90ad-649c3fc44b05",
│                             "last_modified_at": "2023-10-30T14:28:08.449Z",
│                             "last_modified_by_id": "IBMid-6670005V46",
│                             "resources": [
│                                 {
│                                     "attributes": [
│                                         {
│                                             "name": "serviceName",
│                                             "operator": "stringEquals",
│                                             "value": "kms"
│                                         },
│                                         {
│                                             "name": "accountId",
│                                             "operator": "stringEquals",
│                                             "value": "77efe1030c00b5c89cfd08648d3480bf"
│                                         },
│                                         {
│                                             "name": "serviceInstance",
│                                             "operator": "stringEquals",
│                                             "value": "20f2f742-2e3e-4df5-b414-cdd279a05a8a"
│                                         }
│                                     ]
│                                 }
│                             ],
│                             "roles": [
│                                 {
│                                     "description": "As a reader, you can perform read-only actions within a service such as viewing service-specific resources.",
│                                     "display_name": "Reader",
│                                     "role_id": "crn:v1:bluemix:public:iam::::serviceRole:Reader"
│                                 }
│                             ],
│                             "state": "active",
```