### PR TITLE
Improve PR Test: Add Logger for Dynamic Node Wait Failure & Validate Env Setup

### DIFF
--- a/tests/data/lsf_fp14_config.yml
+++ b/tests/data/lsf_fp14_config.yml
@@ -73,7 +73,7 @@ us_south_zone: us-south-1
 us_south_cluster_name: HPC-LSF-2
 jp_tok_zone: jp-tok-1
 jp_tok_cluster_name: HPC-LSF-2
-attracker_test_zone: eu-de-3  #added for testing purpose
+attracker_test_zone: jp-tok-1 #added for testing purpose
 management_instances_image: hpc-lsf-fp14-rhel810-v1   #added for testing purpose
 static_compute_instances_image: hpc-lsf-fp14-compute-rhel810-v1 #added for testing purpose
 dynamic_compute_instances_image: hpc-lsf-fp14-compute-rhel810-v1 #added for testing purpose

--- a/tests/data/lsf_fp15_config.yml
+++ b/tests/data/lsf_fp15_config.yml
@@ -74,7 +74,7 @@ us_south_zone: us-south-1
 us_south_cluster_name: HPC-LSF-2
 jp_tok_zone: jp-tok-1
 jp_tok_cluster_name: HPC-LSF-2
-attracker_test_zone: jp-tok-1  #added for testing purpose
+attracker_test_zone: eu-de-1  #added for testing purpose
 management_instances_image: hpc-lsf-fp15-rhel810-v1   #added for testing purpose
 static_compute_instances_image: hpc-lsf-fp15-compute-rhel810-v1 #added for testing purpose
 dynamic_compute_instances_image: hpc-lsf-fp15-compute-rhel810-v1 #added for testing purpose

--- a/tests/lsf/cluster_validation.go
+++ b/tests/lsf/cluster_validation.go
@@ -219,6 +219,7 @@ func ValidateClusterConfiguration(t *testing.T, options *testhelper.TestOptions,
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -305,6 +306,7 @@ func ValidateClusterConfigurationWithPACHA(t *testing.T, options *testhelper.Tes
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -382,6 +384,7 @@ func ValidateBasicClusterConfiguration(t *testing.T, options *testhelper.TestOpt
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -452,6 +455,7 @@ func ValidateBasicClusterConfigurationWithDynamicProfile(t *testing.T, options *
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -537,6 +541,7 @@ func ValidateLDAPClusterConfiguration(t *testing.T, options *testhelper.TestOpti
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -664,6 +669,7 @@ func ValidatePACANDLDAPClusterConfiguration(t *testing.T, options *testhelper.Te
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -774,6 +780,7 @@ func ValidateExistingLDAPClusterConfig(t *testing.T, ldapServerBastionIP, ldapSe
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -881,6 +888,7 @@ func ValidateBasicClusterConfigurationWithVPCFlowLogsAndCos(t *testing.T, option
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -955,9 +963,10 @@ func ValidateBasicClusterConfigurationLSFLogs(t *testing.T, options *testhelper.
 	sshClient, connectionErr = utils.ConnectToHost(LSF_PUBLIC_HOST_NAME, bastionIP, LSF_PRIVATE_HOST_NAME, managementNodeIPs[0])
 	require.NoError(t, connectionErr, "Failed to re-establish SSH connection after reboot - check node recovery")
 
-	// Wait for dynamic node disappearance
+	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1028,6 +1037,7 @@ func ValidateBasicClusterConfigurationWithDedicatedHost(t *testing.T, options *t
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1098,6 +1108,7 @@ func ValidateBasicClusterConfigurationWithSCC(t *testing.T, options *testhelper.
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1187,6 +1198,7 @@ func ValidateBasicClusterConfigurationWithCloudLogs(t *testing.T, options *testh
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1270,6 +1282,7 @@ func ValidateBasicClusterConfigurationWithCloudMonitoring(t *testing.T, options 
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1349,6 +1362,7 @@ func ValidateBasicClusterConfigurationWithCloudAtracker(t *testing.T, options *t
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1438,9 +1452,10 @@ func ValidateBasicObservabilityClusterConfiguration(t *testing.T, options *testh
 	sshClient, connectionErr = utils.ConnectToHost(LSF_PUBLIC_HOST_NAME, bastionIP, LSF_PRIVATE_HOST_NAME, managementNodeIPs[0])
 	require.NoError(t, connectionErr, "Failed to re-establish SSH connection after reboot - check node recovery")
 
-	// Ensure dynamic worker nodes disappear
+	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1545,6 +1560,7 @@ func ValidateClusterConfigurationWithMultipleKeys(t *testing.T, options *testhel
 	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClientOne, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()
@@ -1618,9 +1634,10 @@ func ValidateBasicClusterConfigurationForMultiProfileStaticAndDynamic(t *testing
 	// Verify management node configuration
 	VerifyManagementNodeConfig(t, sshClient, expected.MasterName, expected.Hyperthreading, managementNodeIPs, expected.LsfVersion, logger)
 
-	// Wait for dynamic node disappearance after job runs
+	// Wait for dynamic node disappearance and handle potential errors
 	defer func() {
 		if err := WaitForDynamicNodeDisappearance(t, sshClient, logger); err != nil {
+			logger.Error(t, fmt.Sprintf("Error in WaitForDynamicNodeDisappearance: %v", err))
 			t.Errorf("Error in WaitForDynamicNodeDisappearance: %v", err)
 		}
 	}()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	deploy "github.com/terraform-ibm-modules/terraform-ibm-hpc/deployment"
 	lsf_tests "github.com/terraform-ibm-modules/terraform-ibm-hpc/lsf_tests"
 	utils "github.com/terraform-ibm-modules/terraform-ibm-hpc/utilities"
@@ -13,6 +14,11 @@ import (
 
 func TestRunDefault(t *testing.T) {
 	t.Parallel()
+
+	require.NoError(t, os.Setenv("ZONES", "us-east-3"), "Failed to set ZONES env variable")
+	require.NoError(t, os.Setenv("DEFAULT_EXISTING_RESOURCE_GROUP", "Default"), "Failed to set DEFAULT_EXISTING_RESOURCE_GROUP")
+
+	t.Log("Running default LSF cluster test for region us-east-3")
 	lsf_tests.DefaultTest(t)
 }
 


### PR DESCRIPTION
### Summary
- Ensured robust environment setup using `require.NoError` for `ZONES` and `DEFAULT_EXISTING_RESOURCE_GROUP`.
- Enhanced logging by adding error-level logger for dynamic node disappearance validation.

### Changes
- `TestRunDefault`: 
  - Added error checks while setting environment variables to avoid silent failures.
  - Added a log statement for test context.
- Cluster validation logic:
  - Added `logger.Error` to capture and report failures in `WaitForDynamicNodeDisappearance`.

### Impact
Improves reliability and observability during test runs and simplifies debugging of dynamic node teardown issues.

### Related
- Part of LSF cluster PR test flow improvements.
