### PR TITLE
Enhance report duration, add KP region support, and refactor VPC test cases

### DIFF
--- a/modules/playbook/main.tf
+++ b/modules/playbook/main.tf
@@ -285,8 +285,8 @@ resource "local_file" "lsf_prerequesite_playbook" {
   become: yes
   vars:
     rpm_urls:
-      "8": "https://rpmfind.net/linux/almalinux/8.10/BaseOS/x86_64/os/Packages/bc-1.07.1-5.el8.x86_64.rpm"
-      "9": "https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/bc-1.07.1-14.el9.x86_64.rpm"
+      "8": "https://vault.centos.org/8-stream/BaseOS/x86_64/os/Packages/bc-1.07.1-5.el8.x86_64.rpm"
+      "9": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/bc-1.07.1-14.el9.x86_64.rpm"
   tasks:
     - name: Check if bc is already installed
       command: rpm -q bc

--- a/tests/lsf_tests/lsf_e2e_test.go
+++ b/tests/lsf_tests/lsf_e2e_test.go
@@ -99,7 +99,7 @@ func TestRunBasic(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting basic cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -149,7 +149,7 @@ func TestRunCustomRGAsNull(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting cluster deployment with null resource group")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -205,7 +205,7 @@ func TestRunCustomRGAsNonDefault(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting cluster deployment with non-default resource group")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -271,7 +271,7 @@ func TestRunSCCEnabled(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting SCC configuration cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -329,7 +329,7 @@ func TestRunNoKMSAndHTOff(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting no-KMS/HT-off cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -357,7 +357,7 @@ func TestRunNoKMSAndHTOff(t *testing.T) {
 // - Valid IBM Cloud API key
 // - Permissions to create/delete KMS instances
 // - Proper test suite initialization
-func TestRunUsingExistingKMS(t *testing.T) {
+func TestRunUsingExistingKMSInstanceAndExistingKey(t *testing.T) {
 	t.Parallel()
 
 	// Initialization
@@ -425,7 +425,7 @@ func TestRunUsingExistingKMS(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting KMS integration cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -445,14 +445,14 @@ func TestRunUsingExistingKMS(t *testing.T) {
 	}
 }
 
-// TestRunUsingExistingKMSInstanceIDAndWithoutKey validates cluster creation with existing KMS instance but no key.
+// TestRunUsingExistingKMSInstanceAndWithoutKey validates cluster creation with existing KMS instance but no key.
 // Verifies proper handling of KMS instance without specified key.
 //
 // Prerequisites:
 // - Valid IBM Cloud API key
 // - Permissions to create/delete KMS instances
 // - Proper test suite initialization
-func TestRunUsingExistingKMSInstanceIDAndWithoutKey(t *testing.T) {
+func TestRunUsingExistingKMSInstanceAndWithoutKey(t *testing.T) {
 	t.Parallel()
 
 	// Initialization
@@ -519,7 +519,7 @@ func TestRunUsingExistingKMSInstanceIDAndWithoutKey(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting KMS integration cluster deployment (without key)")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -583,7 +583,7 @@ func TestRunWithExistingKMSInstanceAndKeyWithAuthorizationPolicy(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting cluster deployment using existing KMS and key with authorization policy")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -658,7 +658,7 @@ func TestRunLSFClusterCreationWithZeroWorkerNodes(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting zero-worker-node cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -724,7 +724,7 @@ func TestRunLDAP(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting LDAP cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -846,7 +846,7 @@ func TestRunExistingLDAP(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting LDAP cluster deployment "+t.Name())
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options2, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -906,7 +906,7 @@ func TestRunCosAndVpcFlowLogs(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting cluster deployment with COS and VPC Flow Logs enabled")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -959,7 +959,7 @@ func TestRunLSFLogs(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting LSF logs cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -1029,7 +1029,7 @@ func TestRunDedicatedHost(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting dedicated host cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -1086,8 +1086,8 @@ func TestObservabilityAllFeaturesDisabled(t *testing.T) {
 	defer options.TestTearDown()
 
 	// Cluster Deployment
-	testLogger.Info(t, "Starting cluster deployment with all observability features disabled")
 	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	err = lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, err, "Cluster creation validation failed")
@@ -1143,8 +1143,8 @@ func TestObservabilityLogsEnabledForManagementAndCompute(t *testing.T) {
 	defer options.TestTearDown()
 
 	// Cluster Deployment
-	testLogger.Info(t, "Starting cluster deployment with management + compute logs enabled")
 	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	err = lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, err, "Cluster creation validation failed")
@@ -1200,8 +1200,8 @@ func TestObservabilityMonitoringEnabledForManagementAndCompute(t *testing.T) {
 	defer options.TestTearDown()
 
 	// Cluster Deployment
-	testLogger.Info(t, "Starting monitoring validation for management and compute")
 	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	err = lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, err, "Cluster creation validation failed")
@@ -1372,7 +1372,7 @@ func TestRunInUsEastRegion(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting US East region cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -1438,7 +1438,7 @@ func TestRunInEuDeRegion(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting EU-DE region cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -1504,7 +1504,7 @@ func TestRunInUSSouthRegion(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting US South region cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -1570,7 +1570,7 @@ func TestRunInJPTokyoRegion(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting Japan Tokyo region cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -1591,313 +1591,6 @@ func TestRunInJPTokyoRegion(t *testing.T) {
 	}
 }
 
-// ******************* Existing VPC ***************************
-
-// TestRunCreateVpc as brand new
-func TestRunCreateVpc(t *testing.T) {
-	// Parallelize the test to run concurrently with others
-	t.Parallel()
-
-	// Set up the test suite and prepare the testing environment
-	setupTestSuite(t)
-
-	testLogger.Info(t, "Brand new VPC creation initiated for "+t.Name())
-
-	// Generate Unique Cluster Prefix
-	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
-	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
-
-	// Get and validate environment variables
-	envVars, err := GetEnvVars()
-	require.NoError(t, err, "Failed to get environment variables")
-
-	// Set up the test options with the relevant parameters, including environment variables and resource group, set up test environment
-	options, err := setupOptionsVPC(t, clusterNamePrefix, createVpcTerraformDir, envVars.DefaultExistingResourceGroup)
-	require.NoError(t, err, "Error setting up test options: %v", err)
-
-	// Skip test teardown for further inspection
-	options.SkipTestTearDown = true
-	defer options.TestTearDown()
-
-	// Run the test
-	testLogger.Info(t, "Starting TestRunCreateVpc  deployment")
-
-	output, err := options.RunTest()
-	require.NoError(t, err, "Error running consistency test: %v", err)
-	require.NotNil(t, output, "Expected non-nil output, but got nil")
-
-	outputs := (options.LastTestTerraformOutputs)
-	vpcName := outputs["vpc_name"].(string)
-
-	bastionsubnetId, computesubnetIds := utils.GetSubnetIds(outputs)
-
-	RunExistingVpcCidr(t, vpcName)
-	RunExistingVpcSubnetIdCustomNullDnsNull(t, vpcName, bastionsubnetId, computesubnetIds)
-}
-
-// RunExistingVpcCidr with Cidr blocks
-func RunExistingVpcCidr(t *testing.T, vpcName string) {
-	fmt.Println("********* Started Executing RunExistingVpcCidr ********* ")
-	// Set up the test suite and prepare the testing environment
-	setupTestSuite(t)
-
-	// Log the initiation of the cluster creation process
-	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
-
-	// Generate Unique Cluster Prefix
-	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
-	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
-
-	// Static values for CIDR other than default CIDR
-	// vpcClusterPrivateSubnetsCidrBlocks := "10.241.8.0/24"
-	// vpcClusterLoginPrivateSubnetsCidrBlocks := "10.241.16.16/28"
-	vpcClusterPrivateSubnetsCidrBlocks := "10.241.32.0/24"
-	vpcClusterLoginPrivateSubnetsCidrBlocks := "10.241.16.32/28"
-
-	// Get and validate environment variables
-	envVars, err := GetEnvVars()
-	require.NoError(t, err, "Failed to get environment variables")
-
-	// Set up the test options with the relevant parameters, including environment variables and resource group
-	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
-	options.TerraformVars["vpc_name"] = vpcName
-	options.TerraformVars["vpc_cluster_private_subnets_cidr_blocks"] = vpcClusterPrivateSubnetsCidrBlocks
-	options.TerraformVars["vpc_cluster_login_private_subnets_cidr_blocks"] = vpcClusterLoginPrivateSubnetsCidrBlocks
-	require.NoError(t, err, "Error setting up test options: %v", err)
-
-	// Skip test teardown for further inspection
-	options.SkipTestTearDown = true
-	defer options.TestTearDown()
-
-	// Cluster Deployment
-	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting deployment: RunExistingVpcCidr")
-
-	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
-	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
-	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
-
-	lsf.ValidateClusterConfiguration(t, options, testLogger)
-	fmt.Println("********* Ended Executing RunExistingVpcCidr ********* ")
-	testLogger.Info(t, "Finished execution: RunExistingVpcCidr")
-}
-
-// RunExistingVpcSubnetIdCustomNullDnsNull with compute and login subnet id. Both custom_resolver and dns_instace null
-func RunExistingVpcSubnetIdCustomNullDnsNull(t *testing.T, vpcName string, bastionsubnetId string, computesubnetIds string) {
-	fmt.Println("********* Started Executing RunExistingVpcSubnetIdCustomNullDnsNull ********* ")
-	// Set up the test suite and prepare the testing environment
-	setupTestSuite(t)
-
-	// Log the initiation of the cluster creation process
-	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
-
-	// Generate Unique Cluster Prefix
-	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
-	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
-
-	// Get and validate environment variables
-	envVars, err := GetEnvVars()
-	require.NoError(t, err, "Failed to get environment variables")
-
-	// Set up the test options with the relevant parameters, including environment variables and resource group
-	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
-	options.TerraformVars["vpc_name"] = vpcName
-	options.TerraformVars["login_subnet_id"] = bastionsubnetId
-	options.TerraformVars["cluster_subnet_id"] = computesubnetIds
-	require.NoError(t, err, "Error setting up test options: %v", err)
-
-	// Skip test teardown for further inspection
-	options.SkipTestTearDown = true
-	defer options.TestTearDown()
-
-	// Cluster Deployment
-	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting deployment: RunExistingVpcSubnetIdCustomNullDnsNull")
-
-	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
-	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
-	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
-
-	lsf.ValidateClusterConfiguration(t, options, testLogger)
-	fmt.Println("********* Ended Executing RunExistingVpcSubnetIdCustomNullDnsNull ********* ")
-	testLogger.Info(t, "Finished execution: RunExistingVpcSubnetIdCustomNullDnsNull")
-}
-
-// TestRunCreateVpcWithCustomDns brand new VPC with DNS
-func TestRunVpcWithCustomDns(t *testing.T) {
-	// Parallelize the test to run concurrently with others
-	t.Parallel()
-
-	// Set up the test suite and prepare the testing environment
-	setupTestSuite(t)
-
-	// Log the initiation of the cluster creation process
-	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
-
-	// Generate Unique Cluster Prefix
-	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
-	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
-
-	// Get and validate environment variables
-	envVars, err := GetEnvVars()
-	require.NoError(t, err, "Failed to get environment variables")
-
-	// Set up the test options with the relevant parameters, including environment variables and resource group, set up test environment
-	options, err := setupOptionsVPC(t, clusterNamePrefix, createVpcTerraformDir, envVars.DefaultExistingResourceGroup)
-	options.TerraformVars["enable_hub"] = true
-	options.TerraformVars["dns_zone_name"] = "lsf.com"
-
-	require.NoError(t, err, "Error setting up test options: %v", err)
-
-	// Skip test teardown for further inspection
-	options.SkipTestTearDown = true
-	defer options.TestTearDown()
-
-	// Run the test
-	testLogger.Info(t, "Starting TestRunVpcWithCustomDns deployment")
-	output, err := options.RunTest()
-	require.NoError(t, err, "Error running consistency test: %v", err)
-	require.NotNil(t, output, "Expected non-nil output, but got nil")
-
-	outputs := (options.LastTestTerraformOutputs)
-	vpcName := outputs["vpc_name"].(string)
-	instanceId, customResolverId := utils.GetDnsCustomResolverIds(outputs)
-	bastionsubnetId, computesubnetIds := utils.GetSubnetIds(outputs)
-
-	RunHpcExistingVpcBothCustomDnsExist(t, vpcName, bastionsubnetId, computesubnetIds, instanceId, customResolverId)
-	RunHpcExistingVpcCustomExistDnsNull(t, vpcName, bastionsubnetId, computesubnetIds, customResolverId)
-	RunHpcExistingVpcCustomNullDnsExist(t, instanceId)
-}
-
-// RunHpcExistingVpcCustomDns with existing custom_resolver_id and dns_instance_id
-func RunHpcExistingVpcBothCustomDnsExist(t *testing.T, vpcName string, bastionsubnetId string, computesubnetIds string, instanceId string, customResolverId string) {
-	fmt.Println("********* Started Executing RunHpcExistingVpcBothCustomDnsExist ********* ")
-	// Set up the test suite and prepare the testing environment
-	setupTestSuite(t)
-
-	// Log the initiation of the cluster creation process
-	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
-
-	// Generate Unique Cluster Prefix
-	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
-	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
-
-	// Get and validate environment variables
-	envVars, err := GetEnvVars()
-	require.NoError(t, err, "Failed to get environment variables")
-
-	// Set up the test options with the relevant parameters, including environment variables and resource group
-	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
-	options.TerraformVars["vpc_name"] = vpcName
-	options.TerraformVars["login_subnet_id"] = bastionsubnetId
-	options.TerraformVars["cluster_subnet_id"] = computesubnetIds
-	options.TerraformVars["dns_instance_id"] = instanceId
-	options.TerraformVars["dns_custom_resolver_id"] = customResolverId
-
-	require.NoError(t, err, "Error setting up test options: %v", err)
-
-	// Skip test teardown for further inspection
-	options.SkipTestTearDown = true
-	defer options.TestTearDown()
-
-	// Cluster Deployment
-	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting deployment: RunHpcExistingVpcBothCustomDnsExist")
-
-	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
-	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
-	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
-
-	lsf.ValidateClusterConfiguration(t, options, testLogger)
-	fmt.Println("********* Ended Executing RunHpcExistingVpcBothCustomDnsExist ********* ")
-	testLogger.Info(t, "Finished execution: RunHpcExistingVpcBothCustomDnsExist")
-
-}
-
-// RunHpcExistingVpcCustomExistDnsNull with existing custom_resolver_id and new dns_instance_id
-func RunHpcExistingVpcCustomExistDnsNull(t *testing.T, vpcName string, bastionsubnetId string, computesubnetIds string, customResolverId string) {
-	fmt.Println("********* Started Executing RunHpcExistingVpcCustomExistDnsNull ********* ")
-	// Set up the test suite and prepare the testing environment
-	setupTestSuite(t)
-
-	// Log the initiation of the cluster creation process
-	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
-
-	// Generate Unique Cluster Prefix
-	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
-	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
-
-	// Get and validate environment variables
-	envVars, err := GetEnvVars()
-	require.NoError(t, err, "Failed to get environment variables")
-
-	// Set up the test options with the relevant parameters, including environment variables and resource group
-	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
-	options.TerraformVars["vpc_name"] = vpcName
-	options.TerraformVars["login_subnet_id"] = bastionsubnetId
-	options.TerraformVars["cluster_subnet_id"] = computesubnetIds
-	options.TerraformVars["dns_custom_resolver_id"] = customResolverId
-
-	require.NoError(t, err, "Error setting up test options: %v", err)
-
-	// Skip test teardown for further inspection
-	options.SkipTestTearDown = true
-	defer options.TestTearDown()
-
-	// Cluster Deployment
-	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting deployment: RunHpcExistingVpcCustomExistDnsNull")
-
-	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
-	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
-	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
-
-	lsf.ValidateClusterConfiguration(t, options, testLogger)
-	fmt.Println("********* Ended Executing RunHpcExistingVpcCustomExistDnsNull ********* ")
-	testLogger.Info(t, "Finished execution: RunHpcExistingVpcCustomExistDnsNull")
-}
-
-// RunHpcExistingVpcCustomNullDnsExist with custom_resolver_id null and existing dns_instance_id
-func RunHpcExistingVpcCustomNullDnsExist(t *testing.T, instanceId string) {
-	fmt.Println("********* Started Executing RunHpcExistingVpcCustomNullDnsExist ********* ")
-	// Set up the test suite and prepare the testing environment
-	setupTestSuite(t)
-
-	// Log the initiation of the cluster creation process
-	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
-
-	// Generate Unique Cluster Prefix
-	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
-	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
-
-	// Get and validate environment variables
-	envVars, err := GetEnvVars()
-	require.NoError(t, err, "Failed to get environment variables")
-
-	// Set up the test options with the relevant parameters, including environment variables and resource group
-	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
-	options.TerraformVars["dns_instance_id"] = instanceId
-
-	require.NoError(t, err, "Error setting up test options: %v", err)
-
-	// Skip test teardown for further inspection
-	options.SkipTestTearDown = true
-	defer options.TestTearDown()
-
-	// Cluster Deployment
-	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting deployment: RunHpcExistingVpcCustomNullDnsExist")
-
-	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
-	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
-	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
-
-	lsf.ValidateClusterConfiguration(t, options, testLogger)
-	fmt.Println("********* Ended Executing RunHpcExistingVpcCustomNullDnsExist ********* ")
-	testLogger.Info(t, "Finished execution: RunHpcExistingVpcCustomNullDnsExist")
-}
-
-// ******************* Existing VPC ***************************
 // TestRunCIDRsAsNonDefault validates that a cluster can be deployed using non-default
 // VPC and subnet CIDR blocks, ensuring isolation and custom networking flexibility.
 func TestRunCIDRsAsNonDefault(t *testing.T) {
@@ -1931,7 +1624,7 @@ func TestRunCIDRsAsNonDefault(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting CIDRs As Non Default deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -1984,7 +1677,7 @@ func TestRunMultipleSSHKeys(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting multiple SSH keys cluster deployment")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -2069,7 +1762,7 @@ func TestRunMultiProfileStaticAndDynamic(t *testing.T) {
 
 	// Cluster Deployment
 	deploymentStart := time.Now()
-	testLogger.Info(t, "Starting cluster deployment with multi-profile static and dynamic nodes")
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
 
 	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
 	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
@@ -2088,3 +1781,372 @@ func TestRunMultiProfileStaticAndDynamic(t *testing.T) {
 		testLogger.PASS(t, fmt.Sprintf("Test %s completed successfully", t.Name()))
 	}
 }
+
+// ******************* Existing VPC ***************************
+
+// TestRunCreateClusterWithExistingVPC as brand new
+func TestRunCreateClusterWithExistingVPC(t *testing.T) {
+	// Parallelize the test to run concurrently with others
+	t.Parallel()
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	testLogger.Info(t, "Brand new VPC creation initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group, set up test environment
+	options, err := setupOptionsVPC(t, clusterNamePrefix, createVpcTerraformDir, envVars.DefaultExistingResourceGroup)
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+	output, err := options.RunTest()
+	require.NoError(t, err, "Error running consistency test: %v", err)
+	require.NotNil(t, output, "Expected non-nil output, but got nil")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	outputs := (options.LastTestTerraformOutputs)
+	vpcName := outputs["vpc_name"].(string)
+
+	bastionsubnetId, computesubnetIds := utils.GetSubnetIds(outputs)
+
+	RunCreateClusterWithExistingVpcCIDRs(t, vpcName)
+	RunCreateClusterWithExistingVpcSubnetsNoDns(t, vpcName, bastionsubnetId, computesubnetIds)
+
+	// Test Result Evaluation
+	if t.Failed() {
+		testLogger.Error(t, fmt.Sprintf("Test %s failed - inspect validation logs", t.Name()))
+	} else {
+		testLogger.PASS(t, fmt.Sprintf("Test %s completed successfully", t.Name()))
+	}
+}
+
+// RunCreateClusterWithExistingVpcCIDRs with Cidr blocks
+func RunCreateClusterWithExistingVpcCIDRs(t *testing.T, vpcName string) {
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	// Log the initiation of the cluster creation process
+	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Static values for CIDR other than default CIDR
+	vpcClusterPrivateSubnetsCidrBlocks := "10.241.32.0/24"
+	vpcClusterLoginPrivateSubnetsCidrBlocks := "10.241.16.32/28"
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group
+	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
+	options.TerraformVars["vpc_name"] = vpcName
+	options.TerraformVars["vpc_cluster_private_subnets_cidr_blocks"] = vpcClusterPrivateSubnetsCidrBlocks
+	options.TerraformVars["vpc_cluster_login_private_subnets_cidr_blocks"] = vpcClusterLoginPrivateSubnetsCidrBlocks
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+
+	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
+	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	lsf.ValidateClusterConfiguration(t, options, testLogger)
+
+	testLogger.Info(t, fmt.Sprintf("Finished execution: %s", t.Name()))
+}
+
+// RunCreateClusterWithExistingVpcSubnetsNoDns with compute and login subnet id. Both custom_resolver and dns_instace null
+func RunCreateClusterWithExistingVpcSubnetsNoDns(t *testing.T, vpcName string, bastionsubnetId string, computesubnetIds string) {
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	// Log the initiation of the cluster creation process
+	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group
+	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
+	options.TerraformVars["vpc_name"] = vpcName
+	options.TerraformVars["login_subnet_id"] = bastionsubnetId
+	options.TerraformVars["cluster_subnet_id"] = computesubnetIds
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+
+	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
+	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	lsf.ValidateClusterConfiguration(t, options, testLogger)
+	testLogger.Info(t, fmt.Sprintf("Finished execution: %s", t.Name()))
+}
+
+// TestRunCreateVpcWithCustomDns brand new VPC with DNS
+func TestRunCreateVpcWithCustomDns(t *testing.T) {
+	// Parallelize the test to run concurrently with others
+	t.Parallel()
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	// Log the initiation of the cluster creation process
+	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group, set up test environment
+	options, err := setupOptionsVPC(t, clusterNamePrefix, createVpcTerraformDir, envVars.DefaultExistingResourceGroup)
+	options.TerraformVars["enable_hub"] = true
+	options.TerraformVars["dns_zone_name"] = "lsf.com"
+
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+	output, err := options.RunTest()
+	require.NoError(t, err, "Error running consistency test: %v", err)
+	require.NotNil(t, output, "Expected non-nil output, but got nil")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	outputs := (options.LastTestTerraformOutputs)
+	vpcName := outputs["vpc_name"].(string)
+	instanceId, customResolverId := utils.GetDnsCustomResolverIds(outputs)
+	bastionsubnetId, computesubnetIds := utils.GetSubnetIds(outputs)
+
+	RunCreateClusterWithDnsAndResolver(t, vpcName, bastionsubnetId, computesubnetIds, instanceId, customResolverId)
+	RunCreateClusterWithOnlyResolver(t, vpcName, bastionsubnetId, computesubnetIds, customResolverId)
+
+	// Test Result Evaluation
+	if t.Failed() {
+		testLogger.Error(t, fmt.Sprintf("Test %s failed - inspect validation logs", t.Name()))
+	} else {
+		testLogger.PASS(t, fmt.Sprintf("Test %s completed successfully", t.Name()))
+	}
+}
+
+// RunCreateClusterWithDnsAndResolver with existing custom_resolver_id and dns_instance_id
+func RunCreateClusterWithDnsAndResolver(t *testing.T, vpcName string, bastionsubnetId string, computesubnetIds string, instanceId string, customResolverId string) {
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	// Log the initiation of the cluster creation process
+	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group
+	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
+	options.TerraformVars["vpc_name"] = vpcName
+	options.TerraformVars["login_subnet_id"] = bastionsubnetId
+	options.TerraformVars["cluster_subnet_id"] = computesubnetIds
+	options.TerraformVars["dns_instance_id"] = instanceId
+	options.TerraformVars["dns_custom_resolver_id"] = customResolverId
+
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+
+	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
+	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	lsf.ValidateClusterConfiguration(t, options, testLogger)
+	testLogger.Info(t, fmt.Sprintf("Finished execution: %s", t.Name()))
+
+}
+
+// RunCreateClusterWithOnlyResolver with existing custom_resolver_id and new dns_instance_id
+func RunCreateClusterWithOnlyResolver(t *testing.T, vpcName string, bastionsubnetId string, computesubnetIds string, customResolverId string) {
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	// Log the initiation of the cluster creation process
+	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group
+	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
+	options.TerraformVars["vpc_name"] = vpcName
+	options.TerraformVars["login_subnet_id"] = bastionsubnetId
+	options.TerraformVars["cluster_subnet_id"] = computesubnetIds
+	options.TerraformVars["dns_custom_resolver_id"] = customResolverId
+
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+
+	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
+	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	lsf.ValidateClusterConfiguration(t, options, testLogger)
+	testLogger.Info(t, fmt.Sprintf("Finished execution: %s", t.Name()))
+}
+
+// TestRunCreateVpcWithCustomDnsOnlyDNS creates a new VPC and uses custom DNS (DNS-only scenario)
+func TestRunCreateVpcWithCustomDnsOnlyDNS(t *testing.T) {
+	// Parallelize the test to run concurrently with others
+	t.Parallel()
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	// Log the initiation of the cluster creation process
+	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group, set up test environment
+	options, err := setupOptionsVPC(t, clusterNamePrefix, createVpcTerraformDir, envVars.DefaultExistingResourceGroup)
+	options.TerraformVars["enable_hub"] = true
+	options.TerraformVars["dns_zone_name"] = "lsf.com"
+
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+	output, err := options.RunTest()
+	require.NoError(t, err, "Error running consistency test: %v", err)
+	require.NotNil(t, output, "Expected non-nil output, but got nil")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	outputs := (options.LastTestTerraformOutputs)
+	instanceId, _ := utils.GetDnsCustomResolverIds(outputs)
+
+	RunCreateClusterWithOnlyDns(t, instanceId)
+
+	// Test Result Evaluation
+	if t.Failed() {
+		testLogger.Error(t, fmt.Sprintf("Test %s failed - inspect validation logs", t.Name()))
+	} else {
+		testLogger.PASS(t, fmt.Sprintf("Test %s completed successfully", t.Name()))
+	}
+}
+
+// RunCreateClusterWithOnlyDns creates a cluster using existing DNS instance (custom_resolver_id = null)
+func RunCreateClusterWithOnlyDns(t *testing.T, instanceId string) {
+
+	// Set up the test suite and prepare the testing environment
+	setupTestSuite(t)
+
+	// Log the initiation of the cluster creation process
+	testLogger.Info(t, "Cluster creation process initiated for "+t.Name())
+
+	// Generate Unique Cluster Prefix
+	clusterNamePrefix := utils.GenerateTimestampedClusterPrefix(utils.GenerateRandomString())
+	testLogger.Info(t, fmt.Sprintf("Generated cluster prefix: %s", clusterNamePrefix))
+
+	// Get and validate environment variables
+	envVars, err := GetEnvVars()
+	require.NoError(t, err, "Failed to get environment variables")
+
+	// Set up the test options with the relevant parameters, including environment variables and resource group
+	options, err := setupOptions(t, clusterNamePrefix, terraformDir, envVars.DefaultExistingResourceGroup)
+	options.TerraformVars["dns_instance_id"] = instanceId
+
+	require.NoError(t, err, "Error setting up test options: %v", err)
+
+	// Skip test teardown for further inspection
+	options.SkipTestTearDown = true
+	defer options.TestTearDown()
+
+	// Cluster Deployment
+	deploymentStart := time.Now()
+	testLogger.Info(t, fmt.Sprintf("Starting cluster deployment for test: %s", t.Name()))
+
+	clusterCreationErr := lsf.VerifyClusterCreationAndConsistency(t, options, testLogger)
+	require.NoError(t, clusterCreationErr, "Cluster creation validation failed")
+	testLogger.Info(t, fmt.Sprintf("Cluster deployment completed (duration: %v)", time.Since(deploymentStart)))
+
+	lsf.ValidateClusterConfiguration(t, options, testLogger)
+	testLogger.Info(t, fmt.Sprintf("Finished execution: %s", t.Name()))
+}
+
+// ******************* Existing VPC ***************************

--- a/tests/utilities/report.go
+++ b/tests/utilities/report.go
@@ -15,7 +15,7 @@ import (
 type TestResult struct {
 	Test    string  `json:"test"`    // Name of the test case
 	Action  string  `json:"action"`  // Test outcome (PASS/FAIL)
-	Elapsed float64 `json:"elapsed"` // Duration in seconds
+	Elapsed float64 `json:"elapsed"` // Duration in minutes (updated from seconds)
 }
 
 // ReportData contains all data needed to generate the HTML report
@@ -24,7 +24,7 @@ type ReportData struct {
 	TotalTests int          `json:"totalTests"` // Total number of tests
 	TotalPass  int          `json:"totalPass"`  // Number of passed tests
 	TotalFail  int          `json:"totalFail"`  // Number of failed tests
-	TotalTime  float64      `json:"totalTime"`  // Total execution time
+	TotalTime  float64      `json:"totalTime"`  // Total execution time (now in minutes)
 	ChartData  string       `json:"chartData"`  // JSON data for charts
 	DateTime   string       `json:"dateTime"`   // Report generation timestamp
 }
@@ -47,7 +47,7 @@ func ParseJSONFile(fileName string) ([]TestResult, error) {
 			results = append(results, TestResult{
 				Test:    matches[2],
 				Action:  matches[1],
-				Elapsed: parseElapsedTime(matches[3]),
+				Elapsed: parseElapsedTime(matches[3]), // Now stores minutes
 			})
 		}
 	}
@@ -98,7 +98,7 @@ type reportStats struct {
 	totalTests int
 	totalPass  int
 	totalFail  int
-	totalTime  float64
+	totalTime  float64 // Now in minutes
 }
 
 // calculateStats computes summary statistics from test results
@@ -113,7 +113,7 @@ func calculateStats(results []TestResult) reportStats {
 		case "FAIL":
 			stats.totalFail++
 		}
-		stats.totalTime += result.Elapsed
+		stats.totalTime += result.Elapsed // Already in minutes
 	}
 
 	return stats
@@ -139,7 +139,6 @@ func writeReport(data ReportData) error {
 		return fmt.Errorf("error writing report: %w", err)
 	}
 
-	//status
 	fmt.Printf("✅ HTML report generated: %s\n", reportFileName)
 	return nil
 }
@@ -152,13 +151,14 @@ func getReportFileName() string {
 	return "test-report-" + time.Now().Format("20060102-150405") + ".html"
 }
 
-// parseElapsedTime converts elapsed time string to float64
+// parseElapsedTime converts elapsed time string to float64 (now in minutes)
 func parseElapsedTime(elapsedStr string) float64 {
-	var elapsed float64
-	if _, err := fmt.Sscanf(elapsedStr, "%f", &elapsed); err != nil {
+	var seconds float64
+	if _, err := fmt.Sscanf(elapsedStr, "%f", &seconds); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to parse elapsed time '%s': %v\n", elapsedStr, err)
+		return 0
 	}
-	return elapsed
+	return seconds / 60 // Convert seconds → minutes
 }
 
 // cleanTemplateOutput processes template output for better HTML formatting
@@ -184,7 +184,7 @@ func closeFile(file *os.File, fileName string) {
 	}
 }
 
-// reportTemplate is the HTML template for the test report
+// reportTemplate is the HTML template for the test report (updated to show "mins")
 const reportTemplate = `<!DOCTYPE html>
 <html>
 <head>
@@ -271,7 +271,7 @@ const reportTemplate = `<!DOCTYPE html>
             </div>
             <div class="metric time-metric">
                 <div>Total Time</div>
-                <div class="metric-value">{{printf "%.2f" .TotalTime}}s</div>
+                <div class="metric-value">{{printf "%.2f" .TotalTime}} mins</div>
             </div>
         </div>
     </div>
@@ -286,7 +286,7 @@ const reportTemplate = `<!DOCTYPE html>
             <tr>
                 <th>Test Name</th>
                 <th>Status</th>
-                <th>Duration (s)</th>
+                <th>Duration (mins)</th>
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION

```

### 📄 **PR Description:**

* Updated `parseElapsedTime()` to show time in minutes for better readability in test reports.
* Added region setting logic for IBM Cloud Key Protect during key creation.
* Made `VerifyTestTerraformOutputs()` dynamic based on input in `cluster_validation.go`.
* Renamed and reorganized existing VPC-related test cases for clarity and better test coverage.
