### PR TITLE
Update KMS Test to Skip IAM Block Storage Authorization Policy

### DIFF
--- a/tests/lsf_tests/lsf_e2e_test.go
+++ b/tests/lsf_tests/lsf_e2e_test.go
@@ -576,6 +576,7 @@ func TestRunWithExistingKMSInstanceAndKeyWithAuthorizationPolicy(t *testing.T) {
 	options.TerraformVars["kms_instance_name"] = envVars.KMSInstanceName
 	options.TerraformVars["kms_key_name"] = envVars.KMSKeyName
 	options.TerraformVars["skip_iam_share_authorization_policy"] = true
+	options.TerraformVars["skip_iam_block_storage_authorization_policy"] = true
 
 	// Cluster Teardown Configuration
 	options.SkipTestTearDown = true


### PR DESCRIPTION
PR Description:
In the TestRunWithExistingKMSInstanceAndKeyWithAuthorizationPolicy test case, set skip_iam_block_storage_authorization_policy to true.
This change ensures the test bypasses IAM authorization policy setup for block storage