### PR TITLE
Fixing Login node unreachable

### DIFF
--- a/modules/ansible-roles/roles/lsf_post_config/tasks/configure_shared_folders.yml
+++ b/modules/ansible-roles/roles/lsf_post_config/tasks/configure_shared_folders.yml
@@ -90,27 +90,27 @@
     - das_staging_area
   when: inventory_hostname == groups['management_nodes'][0]
 
-- name: Read LSF hosts file from shared path
+- name: LoginNode host entry | Read LSF hosts file from shared path
   slurp:
     src: "{{ SHARED_PATH }}/lsf/conf/hosts"
   register: lsf_hosts_file
   when: inventory_hostname == groups['login_node'][0]
 
-- name: Override system /etc/hosts with LSF Login hosts
+- name: LoginNode host entry | Append LSF Login hosts to /etc/hosts
   blockinfile:
     path: /etc/hosts
-    block: "{{ lsf_hosts_file.content | b64decode }}"
-    marker: "# {mark} LSF HOSTS BLOCK"
     create: yes
+    marker: "# {mark} LSF HOSTS BLOCK"
+    insertafter: EOF
+    block: |
+      {{ lsf_hosts_file.content | b64decode }}
   become: yes
   when: inventory_hostname == groups['login_node'][0]
 
-- name: Copy Hosts | Copy LSF hosts file to /etc/hosts
-  ansible.builtin.copy:
-    src: "{{ SHARED_PATH }}/lsf/conf/hosts"
-    dest: /etc/hosts
+- name: LoginNode host entry | Change ownership of /etc/hosts
+  ansible.builtin.file:
+    path: /etc/hosts
     owner: lsfadmin
     group: root
-    mode: preserve
-    remote_src: yes
+  become: yes
   when: inventory_hostname == groups['login_node'][0]

--- a/modules/playbook/main.tf
+++ b/modules/playbook/main.tf
@@ -610,7 +610,7 @@ resource "local_file" "remove_host_entry_playbook" {
   content  = <<EOT
 ---
 - name: Remove managed host entries from /etc/hosts
-  hosts: [mgmt_compute_nodes]
+  hosts: all
   connection: local
   become: yes
   vars:

--- a/modules/resource_provisioner/locals.tf
+++ b/modules/resource_provisioner/locals.tf
@@ -4,7 +4,7 @@ locals {
   deployer_path               = "/opt/ibm"
   remote_terraform_path       = format("%s/terraform-ibm-hpc", local.deployer_path)
   da_hpc_repo_url             = "github.com/terraform-ibm-modules/terraform-ibm-hpc.git"
-  da_hpc_repo_tag             = "lsf-da-20-june" ###### change it to main in future
+  da_hpc_repo_tag             = "login_node_unrechable" ###### change it to main in future
   remote_ansible_path         = format("%s/ibm-spectrumscale-cloud-deploy", local.deployer_path)
   scale_cloud_infra_repo_url  = "https://github.com/jayeshh123/ibm-spectrum-scale-install-infra"
   scale_cloud_infra_repo_name = "ibm-spectrum-scale-install-infra"

--- a/modules/resource_provisioner/locals.tf
+++ b/modules/resource_provisioner/locals.tf
@@ -4,7 +4,7 @@ locals {
   deployer_path               = "/opt/ibm"
   remote_terraform_path       = format("%s/terraform-ibm-hpc", local.deployer_path)
   da_hpc_repo_url             = "github.com/terraform-ibm-modules/terraform-ibm-hpc.git"
-  da_hpc_repo_tag             = "login_node_unrechable" ###### change it to main in future
+  da_hpc_repo_tag             = "lsf-da-20-june" ###### change it to main in future
   remote_ansible_path         = format("%s/ibm-spectrumscale-cloud-deploy", local.deployer_path)
   scale_cloud_infra_repo_url  = "https://github.com/jayeshh123/ibm-spectrum-scale-install-infra"
   scale_cloud_infra_repo_name = "ibm-spectrum-scale-install-infra"

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,11 @@ output "ssh_to_management_node" {
   value       = var.scheduler == "LSF" && (var.enable_deployer == false) && length(local.mgmt_hosts_ips) > 0 ? "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -J ubuntu@${var.bastion_fip} lsfadmin@${local.mgmt_hosts_ips[0]}" : null
 }
 
+output "ssh_to_login_node" {
+  description = "SSH command to connect to the Login node"
+  value       = var.scheduler == "LSF" && (var.enable_deployer == false) ? "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -J ubuntu@${var.bastion_fip} lsfadmin@${local.login_host_ip[0]}" : null
+}
+
 output "ssh_to_ldap_node" {
   description = "SSH command to connect to LDAP node"
   value       = (var.scheduler == "LSF" && var.enable_deployer == false && var.enable_ldap && length(local.ldap_hosts_ips) > 0) ? "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=5 -o ServerAliveCountMax=1 -J ubuntu@${var.bastion_fip} ubuntu@${local.ldap_hosts_ips[0]}" : null

--- a/solutions/lsf/variables.tf
+++ b/solutions/lsf/variables.tf
@@ -536,7 +536,7 @@ variable "ldap_admin_password" {
   description = "The LDAP admin password must be 8 to 20 characters long and include at least two alphabetic characters (with one uppercase and one lowercase), one number, and one special character from the set (!@#$%^&*()_+=-). The password must not contain the username or any spaces. [This value is ignored for an existing LDAP server]."
   validation {
     condition     = (!var.enable_ldap || var.ldap_server != null || can(var.ldap_admin_password != null && length(var.ldap_admin_password) >= 8 && length(var.ldap_admin_password) <= 20 && regex(".*[0-9].*", var.ldap_admin_password) != "" && regex(".*[A-Z].*", var.ldap_admin_password) != "" && regex(".*[a-z].*", var.ldap_admin_password) != "" && regex(".*[!@#$%^&*()_+=-].*", var.ldap_admin_password) != "" && !can(regex(".*\\s.*", var.ldap_admin_password))))
-    error_message = "The LDAP admin password must be 8 to 20 characters long, include uppercase, lowercase, number, special character (!@#$%^&*()_+=-), and have no spaces. Skipped if LDAP is disabled or external server is used."
+    error_message = "The LDAP admin password must be 8 to 20 characters long and include at least two alphabetic characters (with one uppercase and one lowercase), one number, and one special character from the set (!@#$%^&*()_+=-). The password must not contain the username or any spaces."
   }
 }
 

--- a/solutions/lsf/variables.tf
+++ b/solutions/lsf/variables.tf
@@ -535,8 +535,8 @@ variable "ldap_admin_password" {
   default     = null
   description = "The LDAP admin password must be 8 to 20 characters long and include at least two alphabetic characters (with one uppercase and one lowercase), one number, and one special character from the set (!@#$%^&*()_+=-). The password must not contain the username or any spaces. [This value is ignored for an existing LDAP server]."
   validation {
-    condition     = !var.enable_ldap || var.ldap_server != null || length(var.ldap_admin_password) >= 8 && length(var.ldap_admin_password) <= 20 && can(regex("^(.*[0-9]){1}.*$", var.ldap_admin_password)) && can(regex("^(.*[A-Z]){1}.*$", var.ldap_admin_password)) && can(regex("^(.*[a-z]){1}.*$", var.ldap_admin_password)) && can(regex("^.*[!@#$%^&*()_+=-].*$", var.ldap_admin_password)) && !can(regex(".*\\s.*", var.ldap_admin_password))
-    error_message = "The LDAP admin password must be 8 to 20 characters long and include at least two alphabetic characters (with one uppercase and one lowercase), one number, and one special character from the set (!@#$%^&*()_+=-). The password must not contain the username or any spaces."
+    condition = (!var.enable_ldap || var.ldap_server != null || can(var.ldap_admin_password != null && length(var.ldap_admin_password) >= 8 && length(var.ldap_admin_password) <= 20 && regex(".*[0-9].*", var.ldap_admin_password) != "" && regex(".*[A-Z].*", var.ldap_admin_password) != "" && regex(".*[a-z].*", var.ldap_admin_password) != "" && regex(".*[!@#$%^&*()_+=-].*", var.ldap_admin_password) != "" && !can(regex(".*\\s.*", var.ldap_admin_password))))
+    error_message = "The LDAP admin password must be 8 to 20 characters long, include uppercase, lowercase, number, special character (!@#$%^&*()_+=-), and have no spaces. Skipped if LDAP is disabled or external server is used."
   }
 }
 

--- a/solutions/lsf/variables.tf
+++ b/solutions/lsf/variables.tf
@@ -532,7 +532,7 @@ variable "ldap_server_cert" {
 variable "ldap_admin_password" {
   type        = string
   sensitive   = true
-  default     = ""
+  default     = null
   description = "The LDAP admin password must be 8 to 20 characters long and include at least two alphabetic characters (with one uppercase and one lowercase), one number, and one special character from the set (!@#$%^&*()_+=-). The password must not contain the username or any spaces. [This value is ignored for an existing LDAP server]."
   validation {
     condition     = !var.enable_ldap || var.ldap_server != null || length(var.ldap_admin_password) >= 8 && length(var.ldap_admin_password) <= 20 && can(regex("^(.*[0-9]){1}.*$", var.ldap_admin_password)) && can(regex("^(.*[A-Z]){1}.*$", var.ldap_admin_password)) && can(regex("^(.*[a-z]){1}.*$", var.ldap_admin_password)) && can(regex("^.*[!@#$%^&*()_+=-].*$", var.ldap_admin_password)) && !can(regex(".*\\s.*", var.ldap_admin_password))

--- a/solutions/lsf/variables.tf
+++ b/solutions/lsf/variables.tf
@@ -532,7 +532,7 @@ variable "ldap_server_cert" {
 variable "ldap_admin_password" {
   type        = string
   sensitive   = true
-  default     = null
+  default     = ""
   description = "The LDAP admin password must be 8 to 20 characters long and include at least two alphabetic characters (with one uppercase and one lowercase), one number, and one special character from the set (!@#$%^&*()_+=-). The password must not contain the username or any spaces. [This value is ignored for an existing LDAP server]."
   validation {
     condition     = !var.enable_ldap || var.ldap_server != null || length(var.ldap_admin_password) >= 8 && length(var.ldap_admin_password) <= 20 && can(regex("^(.*[0-9]){1}.*$", var.ldap_admin_password)) && can(regex("^(.*[A-Z]){1}.*$", var.ldap_admin_password)) && can(regex("^(.*[a-z]){1}.*$", var.ldap_admin_password)) && can(regex("^.*[!@#$%^&*()_+=-].*$", var.ldap_admin_password)) && !can(regex(".*\\s.*", var.ldap_admin_password))

--- a/solutions/lsf/variables.tf
+++ b/solutions/lsf/variables.tf
@@ -535,7 +535,7 @@ variable "ldap_admin_password" {
   default     = null
   description = "The LDAP admin password must be 8 to 20 characters long and include at least two alphabetic characters (with one uppercase and one lowercase), one number, and one special character from the set (!@#$%^&*()_+=-). The password must not contain the username or any spaces. [This value is ignored for an existing LDAP server]."
   validation {
-    condition = (!var.enable_ldap || var.ldap_server != null || can(var.ldap_admin_password != null && length(var.ldap_admin_password) >= 8 && length(var.ldap_admin_password) <= 20 && regex(".*[0-9].*", var.ldap_admin_password) != "" && regex(".*[A-Z].*", var.ldap_admin_password) != "" && regex(".*[a-z].*", var.ldap_admin_password) != "" && regex(".*[!@#$%^&*()_+=-].*", var.ldap_admin_password) != "" && !can(regex(".*\\s.*", var.ldap_admin_password))))
+    condition     = (!var.enable_ldap || var.ldap_server != null || can(var.ldap_admin_password != null && length(var.ldap_admin_password) >= 8 && length(var.ldap_admin_password) <= 20 && regex(".*[0-9].*", var.ldap_admin_password) != "" && regex(".*[A-Z].*", var.ldap_admin_password) != "" && regex(".*[a-z].*", var.ldap_admin_password) != "" && regex(".*[!@#$%^&*()_+=-].*", var.ldap_admin_password) != "" && !can(regex(".*\\s.*", var.ldap_admin_password))))
     error_message = "The LDAP admin password must be 8 to 20 characters long, include uppercase, lowercase, number, special character (!@#$%^&*()_+=-), and have no spaces. Skipped if LDAP is disabled or external server is used."
   }
 }


### PR DESCRIPTION
**Login Node Output** 

```

module.compute_playbook[0].null_resource.run_playbook_post_deploy_config[0]: Creation complete after 1m28s [id=3484064475448996333]

Apply complete! Resources: 14 added, 0 changed, 13 destroyed.

Outputs:

application_center_tunnel = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=5 -o ServerAliveCountMax=1 -L 8443:10.241.0.4:8443 -L 6080:10.241.0.4:6080 -L 8444:10.241.0.4:8444 -J ubuntu@165.192.140.118 lsfadmin@10.241.16.6"
application_center_url = "https://localhost:8443"
image_details = "LSF Version: fixpack_15 | Management Image: hpc-lsf-fp15-rhel810-v1"
region_name = "jp-tok"
remote_allowed_cidr = tolist([
  "49.37.171.193/32",
])
ssh_to_deployer = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -J ubuntu@165.192.140.118 vpcuser@10.241.16.5"
ssh_to_ldap_node = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=5 -o ServerAliveCountMax=1 -J ubuntu@165.192.140.118 ubuntu@10.241.0.6"
ssh_to_login_node = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -J ubuntu@165.192.140.118 lsfadmin@10.241.16.6"
ssh_to_management_node = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -J ubuntu@165.192.140.118 lsfadmin@10.241.0.4"
vpc_name = "anand-log-lsf"
```