### PR TITLE
fix(deps): lock the DA into terraform version 1.10.5

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -748,7 +748,8 @@
                 "description": "This deployable architecture sets up a VPC on IBM Cloud to run HPC workloads within a single zone. A login node is deployed in a dedicated subnet and security group to facilitate secure access to the HPC environment. The HPC management nodes and static compute nodes reside in a separate subnet and security group.\nClusters of virtual server instances are provisioned with the IBM Spectrum LSF scheduler pre-installed for HPC workload job management. The LSF scheduler dynamically provisions compute nodes as needed and removes them once jobs are completed.\nThe solution supports either IBM Cloud File Storage for VPC or a dedicated clustered shared file system using IBM Storage Scale which is a high performance, highly available, clustered file system with advanced features like File Audit Logging for security and Active File Management for hybrid cloud connectivity. IBM Storage Scale provides more performance and scalability than standard file storage solutions."
               }
             ]
-          }
+          },
+          "terraform_version": "1.10.5"
         }
       ]
     }


### PR DESCRIPTION

        This PR ensures that the `ibm_catalog.json` file includes the required `terraform_version` field.

        An upcoming version of **`common-dev-assets`** will introduce an updated `pre-commit` hook that enforces this check. Applying this change now ensures compatibility with the new hook and avoids future commit failures.
        